### PR TITLE
Add github actions for automating releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Create Release Version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release_on_push:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        uses: rymndhng/release-on-push-action@v0.23.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          bump_version_scheme: norelease
+          tag_prefix: v
+          release_name: "Release <RELEASE_VERSION>"

--- a/.github/workflows/require_label.yml
+++ b/.github/workflows/require_label.yml
@@ -1,0 +1,17 @@
+name: Require PR Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  require_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: exactly
+          count: 1
+          labels: "release:major, release:minor, release:patch, no release"

--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ what this looks like together.
 **Major version 1 is intended to maintain backwards compatibility with the old module source.** To use the new module
 source and maintain compatibility, set your version to `"~> 1"`. This means you will receive any updates that are
 backwards compatible with the old module.
+
+## Contributing
+
+We welcome pull requests for bug fixes and new functionality. Because we use an automated release system, your PR must 
+include a label indicating what type of release should be associated with your change. As is standard for terraform
+registry modules, we utilize [Semantic Versioning](https://semver.org/) for our version numbers. The following are the 
+labels that should be used on your PRs:
+
+* https://github.com/7Factor/terraform-aws-s3-website/labels/release%3Amajor - A release for a major version will be 
+  created after merging the PR.
+* https://github.com/7Factor/terraform-aws-s3-website/labels/release%3Aminor - A release for a minor version will be
+  created after merging the PR.
+* https://github.com/7Factor/terraform-aws-s3-website/labels/release%3Apatch - A release for a patch version will be
+  created after merging the PR.
+* https://github.com/7Factor/terraform-aws-s3-website/labels/no%20release - No release will be created after merging
+  the PR.


### PR DESCRIPTION
The terraform registry automatically picks up new versions of our module whenever a tag in the form of `vX.Y.Z` is applied. This change will automatically create releases (and an associated tag) whenever PRs are merged with appropriate labels. Additionally, it ensures that the developer has chosen one of the release labels by failing a status check if an appropriate label is not applied.