### PR TITLE
add bucket object ownership variable

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -10,13 +10,15 @@ resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
 }
 
 resource "aws_s3_bucket_acl" "web_acl" {
+  count = var.bucket_object_ownership == "BucketOwnerEnforced" ? 0 : 1
   bucket = aws_s3_bucket.web.id
   acl    = "public-read"
 
-  depends_on = [aws_s3_bucket_public_access_block.allow_public_acl, aws_s3_bucket_ownership_controls]
+  depends_on = [aws_s3_bucket_public_access_block.allow_public_acl, aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
 }
 
 resource "aws_s3_bucket_public_access_block" "allow_public_acl" {
+  count = var.bucket_object_ownership == "BucketOwnerEnforced" ? 0 : 1
   bucket            = aws_s3_bucket.web.id
   block_public_acls = false
 }

--- a/s3.tf
+++ b/s3.tf
@@ -2,11 +2,18 @@ resource "aws_s3_bucket" "web" {
   bucket = var.primary_fqdn
 }
 
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.web.id
+  rule {
+    object_ownership = var.bucket_object_ownership
+  }
+}
+
 resource "aws_s3_bucket_acl" "web_acl" {
   bucket = aws_s3_bucket.web.id
   acl    = "public-read"
 
-  depends_on = [aws_s3_bucket_public_access_block.allow_public_acl]
+  depends_on = [aws_s3_bucket_public_access_block.allow_public_acl, aws_s3_bucket_ownership_controls]
 }
 
 resource "aws_s3_bucket_public_access_block" "allow_public_acl" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,8 @@ variable "ordered_cache_behaviors" {
   }))
   default = []
 }
+
+variable "bucket_object_ownership" {
+  description = "See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls#object_ownership : BucketOwnerPreferred, ObjectWriter or BucketOwnerEnforced. Defaults to ObjectWriter."
+  default     = "ObjectWriter"
+}


### PR DESCRIPTION
AWS changed the default settings for new S3 buckets. ACLs and public access are disabled. This module broke attempting to create ACLs for newly created buckets.

The changes made here allow specifying the object ownership of the bucket. The default will be the prior behavior with ACLs allowed.

https://aws.amazon.com/about-aws/whats-new/2023/04/amazon-s3-two-security-best-practices-buckets-default/