### PR TITLE
Allow newer versions of AWS provider.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
`~> 3` only permits major version 3 of the AWS provider. However, there's likely no reason we cannot support anything above 3 as well. `>= 3` will allow this module to be used with 4.x and 5.x of the AWS provider.