### PR TITLE
Optional attachment of WAF to Cloudfront distro

### DIFF
--- a/cf.tf
+++ b/cf.tf
@@ -9,6 +9,8 @@ resource "aws_cloudfront_distribution" "web_distro" {
   default_root_object = var.default_root_object
   aliases             = var.origins
 
+  web_acl_id = var.waf_web_acl_arn
+
   origin {
     domain_name = aws_s3_bucket.web.bucket_regional_domain_name
     origin_id   = var.s3_origin_id

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,8 @@ variable "allow_destroy_s3" {
   type        = bool
   default     = false
 }
+
+variable "waf_web_acl_arn" {
+  description = "The ARN of the WAF Web ACL to associate with the cloudfront distribution. If you want to associate a WAF with the distribution you must provide this value. Do not use an AssociateWebACL"
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,6 @@ variable "allow_destroy_s3" {
 }
 
 variable "waf_web_acl_arn" {
-  description = "The ARN of the WAF Web ACL to associate with the cloudfront distribution. If you want to associate a WAF with the distribution you must provide this value. Do not use an AssociateWebACL"
-  default = ""
+  description = "The ARN of the WAF Web ACL to associate with the cloudfront distribution. If you want to associate a WAF with the distribution you must provide this value. Do not use an AssociateWebACL. Defaults to null."
+  default     = null
 }


### PR DESCRIPTION
AWS/terraform doesn't want users to use WAF association modules to connect Cloudfronts to WAFs. Instead they ask you to give the WAF ARN directly to the Cloudfront module via the  `web_acl_id` field.

[Detailed here in the terraform documentation.](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association)

Since the Cloudfront distro is inside of this aws s3 website module, and isn't available for referencing, I added an optional variable to allow attaching a WAF.

Tested and confirmed that the default value of null causes no changes, so I expect no changes to existing deploys.